### PR TITLE
Cast ClickHouse columns to UInt32 for numeric constants

### DIFF
--- a/daffodil/clickhouse_query_delegate.pyx
+++ b/daffodil/clickhouse_query_delegate.pyx
@@ -71,7 +71,7 @@ cdef class ClickHouseQueryDelegate(BaseDaffodilDelegate):
             add_not_null = False
             if isinstance(val_obj, list) and val_obj:
                 if all(isinstance(v, int) and not isinstance(v, bool) for v in val_obj):
-                    cast_expr = f"toUInt32OrNull({key_expr})"
+                    cast_expr = f"toUInt32OrNull(toString({key_expr}))"
                     add_not_null = True
                 elif all(isinstance(v, str) for v in val_obj):
                     cast_expr = f"toString({key_expr})"
@@ -88,7 +88,7 @@ cdef class ClickHouseQueryDelegate(BaseDaffodilDelegate):
             cast_expr = key_expr
             add_not_null = False
             if isinstance(val_obj, int) and not isinstance(val_obj, bool):
-                cast_expr = f"toUInt32OrNull({key_expr})"
+                cast_expr = f"toUInt32OrNull(toString({key_expr}))"
                 add_not_null = True
             if op == "!=":
                 return f"({cast_expr} != {val_expr}) OR ({key_expr} IS NULL)"

--- a/daffodil/clickhouse_query_delegate.pyx
+++ b/daffodil/clickhouse_query_delegate.pyx
@@ -68,24 +68,34 @@ cdef class ClickHouseQueryDelegate(BaseDaffodilDelegate):
 
         if op in ("in", "!in"):
             cast_expr = key_expr
+            add_not_null = False
             if isinstance(val_obj, list) and val_obj:
                 if all(isinstance(v, int) and not isinstance(v, bool) for v in val_obj):
                     cast_expr = f"toUInt32({key_expr})"
+                    add_not_null = True
                 elif all(isinstance(v, str) for v in val_obj):
                     cast_expr = f"toString({key_expr})"
             val_expr = self._format_value(val_obj)
             if op == "in":
-                return f"{cast_expr} IN {val_expr}"
+                expr = f"{cast_expr} IN {val_expr}"
             else:
-                return f"{cast_expr} NOT IN {val_expr}"
+                expr = f"{cast_expr} NOT IN {val_expr}"
+            if add_not_null:
+                return f"({expr} AND ({key_expr} IS NOT NULL))"
+            return expr
         else:
             val_expr = self._format_value(val_obj)
             cast_expr = key_expr
+            add_not_null = False
             if isinstance(val_obj, int) and not isinstance(val_obj, bool):
                 cast_expr = f"toUInt32({key_expr})"
+                add_not_null = True
             if op == "!=":
                 return f"({cast_expr} != {val_expr}) OR ({key_expr} IS NULL)"
-            return f"{cast_expr} {op} {val_expr}"
+            expr = f"{cast_expr} {op} {val_expr}"
+            if add_not_null:
+                return f"({expr} AND ({key_expr} IS NOT NULL))"
+            return expr
 
     def call(self, predicate, query=None):
         return predicate

--- a/daffodil/clickhouse_query_delegate.pyx
+++ b/daffodil/clickhouse_query_delegate.pyx
@@ -71,7 +71,7 @@ cdef class ClickHouseQueryDelegate(BaseDaffodilDelegate):
             add_not_null = False
             if isinstance(val_obj, list) and val_obj:
                 if all(isinstance(v, int) and not isinstance(v, bool) for v in val_obj):
-                    cast_expr = f"toUInt32({key_expr})"
+                    cast_expr = f"toUInt32OrNull({key_expr})"
                     add_not_null = True
                 elif all(isinstance(v, str) for v in val_obj):
                     cast_expr = f"toString({key_expr})"
@@ -88,7 +88,7 @@ cdef class ClickHouseQueryDelegate(BaseDaffodilDelegate):
             cast_expr = key_expr
             add_not_null = False
             if isinstance(val_obj, int) and not isinstance(val_obj, bool):
-                cast_expr = f"toUInt32({key_expr})"
+                cast_expr = f"toUInt32OrNull({key_expr})"
                 add_not_null = True
             if op == "!=":
                 return f"({cast_expr} != {val_expr}) OR ({key_expr} IS NULL)"

--- a/test/test_clickhouse.py
+++ b/test/test_clickhouse.py
@@ -10,7 +10,7 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_simple(self):
         sql = self._render('zip_code = 8002')
-        self.assertEqual(sql, "((toUInt32OrNull(hs_data.zip_code) = 8002) AND (hs_data.zip_code IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(toString(hs_data.zip_code)) = 8002) AND (hs_data.zip_code IS NOT NULL))")
 
     def test_medium(self):
         fltr = '[ dbn = "01M292"\n  dbn = "01M448" ]'
@@ -19,7 +19,7 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_advanced(self):
         fltr = '{\n  tag_with_null_value ?= true\n  sat_math_avg_score >= 500\n  ![\n    zip_code = 10004\n    zip_code = 10002\n  ]\n}'
-        expected = "((isNotNull(hs_data.tag_with_null_value)) AND ((toUInt32OrNull(hs_data.sat_math_avg_score) >= 500) AND (hs_data.sat_math_avg_score IS NOT NULL)) AND (NOT (((toUInt32OrNull(hs_data.zip_code) = 10004) AND (hs_data.zip_code IS NOT NULL)) OR ((toUInt32OrNull(hs_data.zip_code) = 10002) AND (hs_data.zip_code IS NOT NULL)))))"
+        expected = "((isNotNull(hs_data.tag_with_null_value)) AND ((toUInt32OrNull(toString(hs_data.sat_math_avg_score)) >= 500) AND (hs_data.sat_math_avg_score IS NOT NULL)) AND (NOT (((toUInt32OrNull(toString(hs_data.zip_code)) = 10004) AND (hs_data.zip_code IS NOT NULL)) OR ((toUInt32OrNull(toString(hs_data.zip_code)) = 10002) AND (hs_data.zip_code IS NOT NULL)))))"
         self.assertEqual(self._render(fltr), expected)
 
     def test_timestamp(self):
@@ -28,21 +28,21 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_uint32_casting(self):
         sql = self._render('field_month = 202411')
-        self.assertEqual(sql, "((toUInt32OrNull(hs_data.field_month) = 202411) AND (hs_data.field_month IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(toString(hs_data.field_month)) = 202411) AND (hs_data.field_month IS NOT NULL))")
 
         sql = self._render('field_month in (202411, 202412)')
-        self.assertEqual(sql, "((toUInt32OrNull(hs_data.field_month) IN (202411, 202412)) AND (hs_data.field_month IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(toString(hs_data.field_month)) IN (202411, 202412)) AND (hs_data.field_month IS NOT NULL))")
 
         sql = self._render('field_month < 202501')
-        self.assertEqual(sql, "((toUInt32OrNull(hs_data.field_month) < 202501) AND (hs_data.field_month IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(toString(hs_data.field_month)) < 202501) AND (hs_data.field_month IS NOT NULL))")
 
     def test_in_operators(self):
         sql = self._render('num_of_sat_test_takers in (50, 60)')
         self.assertEqual(sql,
-                         "((toUInt32OrNull(hs_data.num_of_sat_test_takers) IN (50, 60)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
+                         "((toUInt32OrNull(toString(hs_data.num_of_sat_test_takers)) IN (50, 60)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
         sql = self._render('num_of_sat_test_takers !in (50)')
         self.assertEqual(sql,
-                         "((toUInt32OrNull(hs_data.num_of_sat_test_takers) NOT IN (50)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
+                         "((toUInt32OrNull(toString(hs_data.num_of_sat_test_takers)) NOT IN (50)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
 
     def test_in_string_operators(self):
         sql = self._render('dbn in ("01M292", "01M448")')

--- a/test/test_clickhouse.py
+++ b/test/test_clickhouse.py
@@ -10,7 +10,7 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_simple(self):
         sql = self._render('zip_code = 8002')
-        self.assertEqual(sql, "(toUInt32(hs_data.zip_code) = 8002)")
+        self.assertEqual(sql, "((toUInt32(hs_data.zip_code) = 8002) AND (hs_data.zip_code IS NOT NULL))")
 
     def test_medium(self):
         fltr = '[ dbn = "01M292"\n  dbn = "01M448" ]'
@@ -19,7 +19,7 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_advanced(self):
         fltr = '{\n  tag_with_null_value ?= true\n  sat_math_avg_score >= 500\n  ![\n    zip_code = 10004\n    zip_code = 10002\n  ]\n}'
-        expected = "((isNotNull(hs_data.tag_with_null_value)) AND (toUInt32(hs_data.sat_math_avg_score) >= 500) AND (NOT ((toUInt32(hs_data.zip_code) = 10004) OR (toUInt32(hs_data.zip_code) = 10002))))"
+        expected = "((isNotNull(hs_data.tag_with_null_value)) AND ((toUInt32(hs_data.sat_math_avg_score) >= 500) AND (hs_data.sat_math_avg_score IS NOT NULL)) AND (NOT (((toUInt32(hs_data.zip_code) = 10004) AND (hs_data.zip_code IS NOT NULL)) OR ((toUInt32(hs_data.zip_code) = 10002) AND (hs_data.zip_code IS NOT NULL)))))"
         self.assertEqual(self._render(fltr), expected)
 
     def test_timestamp(self):
@@ -28,21 +28,21 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_uint32_casting(self):
         sql = self._render('field_month = 202411')
-        self.assertEqual(sql, "(toUInt32(hs_data.field_month) = 202411)")
+        self.assertEqual(sql, "((toUInt32(hs_data.field_month) = 202411) AND (hs_data.field_month IS NOT NULL))")
 
         sql = self._render('field_month in (202411, 202412)')
-        self.assertEqual(sql, "(toUInt32(hs_data.field_month) IN (202411, 202412))")
+        self.assertEqual(sql, "((toUInt32(hs_data.field_month) IN (202411, 202412)) AND (hs_data.field_month IS NOT NULL))")
 
         sql = self._render('field_month < 202501')
-        self.assertEqual(sql, "(toUInt32(hs_data.field_month) < 202501)")
+        self.assertEqual(sql, "((toUInt32(hs_data.field_month) < 202501) AND (hs_data.field_month IS NOT NULL))")
 
     def test_in_operators(self):
         sql = self._render('num_of_sat_test_takers in (50, 60)')
         self.assertEqual(sql,
-                         "(toUInt32(hs_data.num_of_sat_test_takers) IN (50, 60))")
+                         "((toUInt32(hs_data.num_of_sat_test_takers) IN (50, 60)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
         sql = self._render('num_of_sat_test_takers !in (50)')
         self.assertEqual(sql,
-                         "(toUInt32(hs_data.num_of_sat_test_takers) NOT IN (50))")
+                         "((toUInt32(hs_data.num_of_sat_test_takers) NOT IN (50)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
 
     def test_in_string_operators(self):
         sql = self._render('dbn in ("01M292", "01M448")')

--- a/test/test_clickhouse.py
+++ b/test/test_clickhouse.py
@@ -10,7 +10,7 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_simple(self):
         sql = self._render('zip_code = 8002')
-        self.assertEqual(sql, "((toUInt32(hs_data.zip_code) = 8002) AND (hs_data.zip_code IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(hs_data.zip_code) = 8002) AND (hs_data.zip_code IS NOT NULL))")
 
     def test_medium(self):
         fltr = '[ dbn = "01M292"\n  dbn = "01M448" ]'
@@ -19,7 +19,7 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_advanced(self):
         fltr = '{\n  tag_with_null_value ?= true\n  sat_math_avg_score >= 500\n  ![\n    zip_code = 10004\n    zip_code = 10002\n  ]\n}'
-        expected = "((isNotNull(hs_data.tag_with_null_value)) AND ((toUInt32(hs_data.sat_math_avg_score) >= 500) AND (hs_data.sat_math_avg_score IS NOT NULL)) AND (NOT (((toUInt32(hs_data.zip_code) = 10004) AND (hs_data.zip_code IS NOT NULL)) OR ((toUInt32(hs_data.zip_code) = 10002) AND (hs_data.zip_code IS NOT NULL)))))"
+        expected = "((isNotNull(hs_data.tag_with_null_value)) AND ((toUInt32OrNull(hs_data.sat_math_avg_score) >= 500) AND (hs_data.sat_math_avg_score IS NOT NULL)) AND (NOT (((toUInt32OrNull(hs_data.zip_code) = 10004) AND (hs_data.zip_code IS NOT NULL)) OR ((toUInt32OrNull(hs_data.zip_code) = 10002) AND (hs_data.zip_code IS NOT NULL)))))"
         self.assertEqual(self._render(fltr), expected)
 
     def test_timestamp(self):
@@ -28,21 +28,21 @@ class ClickHouseDelegateTests(unittest.TestCase):
 
     def test_uint32_casting(self):
         sql = self._render('field_month = 202411')
-        self.assertEqual(sql, "((toUInt32(hs_data.field_month) = 202411) AND (hs_data.field_month IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(hs_data.field_month) = 202411) AND (hs_data.field_month IS NOT NULL))")
 
         sql = self._render('field_month in (202411, 202412)')
-        self.assertEqual(sql, "((toUInt32(hs_data.field_month) IN (202411, 202412)) AND (hs_data.field_month IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(hs_data.field_month) IN (202411, 202412)) AND (hs_data.field_month IS NOT NULL))")
 
         sql = self._render('field_month < 202501')
-        self.assertEqual(sql, "((toUInt32(hs_data.field_month) < 202501) AND (hs_data.field_month IS NOT NULL))")
+        self.assertEqual(sql, "((toUInt32OrNull(hs_data.field_month) < 202501) AND (hs_data.field_month IS NOT NULL))")
 
     def test_in_operators(self):
         sql = self._render('num_of_sat_test_takers in (50, 60)')
         self.assertEqual(sql,
-                         "((toUInt32(hs_data.num_of_sat_test_takers) IN (50, 60)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
+                         "((toUInt32OrNull(hs_data.num_of_sat_test_takers) IN (50, 60)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
         sql = self._render('num_of_sat_test_takers !in (50)')
         self.assertEqual(sql,
-                         "((toUInt32(hs_data.num_of_sat_test_takers) NOT IN (50)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
+                         "((toUInt32OrNull(hs_data.num_of_sat_test_takers) NOT IN (50)) AND (hs_data.num_of_sat_test_takers IS NOT NULL))")
 
     def test_in_string_operators(self):
         sql = self._render('dbn in ("01M292", "01M448")')


### PR DESCRIPTION
## Summary
- cast numeric comparisons to UInt32 in the ClickHouse delegate
- update ClickHouse tests to expect UInt32 casts
- add new test covering casting for `=`, `in` and `<`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*
- `python test/test_clickhouse.py` *(fails: ModuleNotFoundError: No module named 'daffodil')*

------
https://chatgpt.com/codex/tasks/task_e_6874f9232008832c8c92540663c6a11f